### PR TITLE
Series of encoding related patches

### DIFF
--- a/lib/libebook/ebook_chm.cpp
+++ b/lib/libebook/ebook_chm.cpp
@@ -85,7 +85,7 @@ QString EBook_CHM::title() const
 
 QUrl EBook_CHM::homeUrl() const
 {
-	return pathToUrl( m_home );
+	return pathToUrl( encodeWithCurrentCodec(m_home) );
 }
 
 bool EBook_CHM::hasFeature(EBook::Feature code) const
@@ -113,7 +113,7 @@ bool EBook_CHM::getTableOfContents( QList<EBookTocEntry> &toc ) const
 	// Parse the plain text TOC
 	QList< ParsedEntry > parsed;
 
-	if ( !parseFileAndFillArray( m_topicsFile, parsed, false ) )
+	if ( !parseFileAndFillArray( encodeWithCurrentCodec(m_topicsFile), parsed, false ) )
 		return false;
 
 	// Find out the root offset, and reduce the indent level to it
@@ -146,7 +146,7 @@ bool EBook_CHM::getIndex(QList<EBookIndexEntry> &index) const
 	// Parse the plain text index
 	QList< ParsedEntry > parsed;
 
-	if ( !parseFileAndFillArray( m_indexFile, parsed, true ) )
+	if ( !parseFileAndFillArray( encodeWithCurrentCodec(m_indexFile), parsed, true ) )
 		return false;
 
 	// Find out the root offset, and reduce the indent level to it

--- a/lib/libebook/ebook_chm.cpp
+++ b/lib/libebook/ebook_chm.cpp
@@ -227,7 +227,7 @@ bool EBook_CHM::getTextContent( QString& str, const QString& url, bool internal_
 			buf.resize( length + 1 );
 			buf [length] = '\0';
 
-			str = internal_encoding ? (QString)( buf.constData() ) :  encodeWithCurrentCodec( buf.constData() );
+			str = internal_encoding ? encodeInternalWithCurrentCodec( buf.constData() ) :  encodeWithCurrentCodec( buf.constData() );
 			return true;
 		}
 	}
@@ -379,7 +379,7 @@ bool EBook_CHM::parseFileAndFillArray( const QString& file, QList< ParsedEntry >
 	QString src;
 	const int MAX_NEST_DEPTH = 256;
 
-	if ( !getTextContent( src, file ) || src.isEmpty() )
+	if ( !getTextContent( src, file, true ) || src.isEmpty() )
 		return false;
 
 /*
@@ -976,7 +976,7 @@ bool EBook_CHM::RecurseLoadBTOC( const QByteArray& tocidx,
 					return false;
 				}
 
-				name = encodeWithCurrentCodec( strings.data() + index);
+				name = encodeInternalWithCurrentCodec( strings.data() + index);
 			}
 			else
 			{
@@ -997,7 +997,7 @@ bool EBook_CHM::RecurseLoadBTOC( const QByteArray& tocidx,
 				if ( tocoffset < 0 )
 					name.clear();
 				else
-					name = encodeWithCurrentCodec( strings.data() + tocoffset );
+					name = encodeInternalWithCurrentCodec( strings.data() + tocoffset );
 
 				// #URLTBL index
 				tocoffset = (int) UINT32ARRAY( topics.data() + (index * 16) + 8 );
@@ -1016,7 +1016,7 @@ bool EBook_CHM::RecurseLoadBTOC( const QByteArray& tocidx,
 					return false;
 				}
 
-				value = encodeWithCurrentCodec( urlstr.data() + tocoffset + 8 );
+				value = encodeInternalWithCurrentCodec( urlstr.data() + tocoffset + 8 );
 			}
 
 			EBookTocEntry entry;

--- a/lib/libebook/ebook_chm.cpp
+++ b/lib/libebook/ebook_chm.cpp
@@ -879,6 +879,8 @@ bool EBook_CHM::changeFileEncoding( const QString& qtencoding  )
 		}
 	}
 
+	m_url2topics.clear();
+	fillTopicsUrlMap();
 	m_htmlEntityDecoder.changeEncoding( m_textCodec );
 	return true;
 }

--- a/src/textencodings.cpp
+++ b/src/textencodings.cpp
@@ -57,6 +57,16 @@ static const TextEncodingEntry text_encoding_table [] =
 	},
 
 	{
+		"Chinese Simplified",
+		"UTF-8/GBK"
+	},
+
+	{
+		"Chinese Simplified",
+		"GBK/UTF-8"
+	},
+
+	{
 		"Chinese Traditional",
 		"Big5"
 	},


### PR DESCRIPTION
Some chm files use different encodings for the html content and the index, e.g. [this one](http://ys-c.ys168.com/116124374/n2K753I657LGMgkw6gJ/%E5%B0%8F%E9%B9%A4%E9%9F%B3%E5%BD%A2%E5%85%A5%E9%97%A8.chm).

Without this patches, kchmviewer can not display both html content and index correctly.

Without patches, set encoding to UTF-8:
![2018-11-23-15 22 53](https://user-images.githubusercontent.com/9315/48931874-aaa34f00-ef33-11e8-8589-dd437a31052e.png)

Without patches, set encoding to GBK:
![2018-11-23-15 24 23](https://user-images.githubusercontent.com/9315/48931920-de7e7480-ef33-11e8-900f-f85d560e0356.png)

With patches, set encoding to UTF-8/GBK:
![2018-11-23-15 25 33](https://user-images.githubusercontent.com/9315/48931968-0ff74000-ef34-11e8-8e80-2926e1f4db83.png)

Please give any feedback, about what need be to changed, or a better solution.