### PR TITLE
QtWebengine fixes

### DIFF
--- a/src/viewwindow_webengine.cpp
+++ b/src/viewwindow_webengine.cpp
@@ -290,6 +290,36 @@ void ViewWindow::contextMenuEvent(QContextMenuEvent *e)
     delete m;
 }
 
+QWebEngineView *ViewWindow::createWindow(QWebEnginePage::WebWindowType type)
+{
+    QWebEngineView *tab = nullptr;
+
+    switch (type)
+    {
+    case QWebEnginePage::WebBrowserWindow:
+    case QWebEnginePage::WebBrowserTab:
+    case QWebEnginePage::WebBrowserBackgroundTab:
+        {
+            bool active = (type != QWebEnginePage::WebBrowserBackgroundTab);
+
+            tab = ::mainWindow->viewWindowMgr()->addNewTab(active);
+            tab->setZoomFactor( ::mainWindow->currentBrowser()->zoomFactor() );
+
+            if (active)
+            {
+                tab->setFocus( Qt::OtherFocusReason );
+            }
+        }
+        break;
+
+    case QWebEnginePage::WebDialog:
+        // TODO: implement
+        break;
+    }
+
+    return tab;
+}
+
 void ViewWindow::onLoadFinished ( bool )
 {
     // If m_storedScrollbarPosition is -1 this means we have not had a request to set the scrollbar; change to 0

--- a/src/viewwindow_webengine.cpp
+++ b/src/viewwindow_webengine.cpp
@@ -30,6 +30,7 @@
 #include "config.h"
 #include "viewwindow_webengine.h"
 #include "mainwindow.h"
+#include "navigationpanel.h"
 #include "viewwindowmgr.h"
 #include "ebook_chm.h"
 #include "ebook_epub.h"
@@ -86,10 +87,15 @@ ViewWindow::ViewWindow( QWidget * parent )
     pal.setColor( QPalette::Inactive, QPalette::Highlight, pal.color(QPalette::Active, QPalette::Highlight) );
     pal.setColor( QPalette::Inactive, QPalette::HighlightedText, pal.color(QPalette::Active, QPalette::HighlightedText) );
     setPalette( pal );
+
+    connect(this, &QWebEngineView::urlChanged, [this] (const QUrl &url) {
+        ::mainWindow->navigator()->findUrlInContents(url);
+    });
 }
 
 ViewWindow::~ViewWindow()
 {
+    disconnect(this, &QWebEngineView::urlChanged, nullptr, nullptr);
 }
 
 void ViewWindow::invalidate( )

--- a/src/viewwindow_webengine.h
+++ b/src/viewwindow_webengine.h
@@ -112,6 +112,8 @@ class ViewWindow : public QWebEngineView
         void 			contextMenuEvent( QContextMenuEvent *e );
         //void			mouseReleaseEvent ( QMouseEvent * event );
 
+        virtual QWebEngineView* createWindow(QWebEnginePage::WebWindowType type) override;
+
     private slots:
         // Used to restore the scrollbar position and the navigation button status
         void			onLoadFinished ( bool ok );

--- a/src/viewwindowmgr.cpp
+++ b/src/viewwindowmgr.cpp
@@ -142,11 +142,13 @@ ViewWindow * ViewWindowMgr::addNewTab( bool set_active )
 	if ( set_active || m_Windows.size() == 1 )
 		m_tabWidget->setCurrentWidget( tabdata.widget );
 	
+#if defined (USE_WEBKIT)
 	// Handle clicking on link in browser window
 	connect( viewvnd,
 			 SIGNAL( linkClicked ( const QUrl& ) ),
 	         ::mainWindow, 
 			 SLOT( activateUrl( const QUrl& ) ) );
+#endif
 
     connect( viewvnd, SIGNAL(dataLoaded(ViewWindow*)), this, SLOT(onWindowContentChanged(ViewWindow*)));
 


### PR DESCRIPTION
Three improvements for QtWebengine support:

1) don't try using linkClicked signal. There is no such signal when using QtWebengine.
2) Allow to open new windows with shift+click. Dialog windows need implementation, but other window types work fine.
3) select appropriate item in contents tab when url changes.