### PR TITLE
Return initialization of EBook_CHM :: m_lookupTablesValid

### DIFF
--- a/lib/libebook/ebook_chm.cpp
+++ b/lib/libebook/ebook_chm.cpp
@@ -51,6 +51,7 @@ EBook_CHM::EBook_CHM()
 	m_detectedLCID = 0;
 	m_currentEncoding = "UTF-8";
 	m_htmlEntityDecoder = 0;
+	m_lookupTablesValid = false;
 }
 
 EBook_CHM::~EBook_CHM()
@@ -76,6 +77,7 @@ void EBook_CHM::close()
 	m_textCodecForSpecialFiles = 0;
 	m_detectedLCID = 0;
 	m_currentEncoding = "UTF-8";
+	m_lookupTablesValid = false;
 }
 
 QString EBook_CHM::title() const
@@ -295,8 +297,6 @@ bool EBook_CHM::load(const QString &archiveName)
 		m_lookupTablesValid = true;
 		fillTopicsUrlMap();
 	}
-	else
-		m_lookupTablesValid = false;
 
 	// Some CHM files have toc and index files, but do not set the name properly.
 	// Some heuristics here.


### PR DESCRIPTION
The `load` function calls `guessTextEncoding` before attempting to update the `m_chmTOPICS`, `m_chmSTRINGS`, `m_chmURLTBL` and `m_chmURLSTR` objects. Thus, at the time `guessTextEncoding` is called, these objects and the `m_lookupTablesValid` flag contain an invalid value. However, `guessTextEncoding` can (via `changeFileEncoding`) implicitly call `fillTopicsUrlMap`, which uses these objects and a flag. In some cases, the combination of object parameters causes the application to crash due to lack of memory.

There were similar changes in fe6c414, but they got lost in the refactoring in 2bab405 and were permanently removed in f613164.