### PR TITLE
Specify that this repo supersedes SourceForge repo

### DIFF
--- a/README
+++ b/README
@@ -6,6 +6,8 @@ The main advantage of KchmViewer is extended support for non-English languages. 
 
 KchmViewer is written by Georgy Yunaev (gyunaev@ulduzsoft.com), and is licensed under GNU GPL license. Please do NOT use this email for bug reporting; see below.
 
+The GitHub repository (https://github.com/gyunaev/kchmviewer) supersedes the SourceForge repository (https://sourceforge.net/projects/kchmviewer).
+
 
 2. FEATURES
 


### PR DESCRIPTION
It appears that this repo now supersedes the SourceForge repo.  If this is accurate, it will be good to indicate this in the README.